### PR TITLE
Allow octosend tracking to be disabled

### DIFF
--- a/src/OctoSend/API.php
+++ b/src/OctoSend/API.php
@@ -203,7 +203,8 @@ class API
             $html = null,
             $text = null,
             array $tags = [],
-            $draft = false
+            $draft = false,
+            $tracking = true
         ) {
             $params = [
                 'fromEmail' => $fromEmail,
@@ -234,6 +235,10 @@ class API
                     "type" => "text/html",
                     "content" => $html
                 ];
+            }
+
+            if($tracking===false) {
+                $params['tracking'] = false;
             }
 
             return $this->rest_call("domain/$name/transactional/send-mail", $params, "POST");


### PR DESCRIPTION
Add param in dictionnary given to API to enable / disable octosend tracking.
Argument added to  domain_send_transactionnal() function as optional with default to true (no change to current behavior)